### PR TITLE
energy 1.0.0 (new formula)

### DIFF
--- a/Formula/d/energy.rb
+++ b/Formula/d/energy.rb
@@ -1,0 +1,26 @@
+class Energy < Formula
+  desc "CLI is used to initialize the Energy development environment tools"
+  homepage "https://energye.github.io"
+  url "https://github.com/energye/energy/archive/refs/tags/v2.4.5.tar.gz"
+  sha256 "157beb93773637b75ffd0d72cc5ba3303d39065f6448b5272b5d9350da2eb47e"
+  license "Apache-2.0"
+
+  depends_on "go" => :build
+
+  def install
+    cd "cmd/energy" do
+      system "go", "build", *std_go_args(ldflags: "-s -w")
+    end
+  end
+
+  test do
+    output = shell_output("#{bin}/energy cli -v 2>&1")
+    assert_match "Current", output
+    assert_match "Latest", output
+
+    output = shell_output("#{bin}/energy env 2>&1")
+    assert_match "Get ENERGY Framework Development Environment", output
+    assert_match "GOROOT", output
+    assert_match "ENERGY_HOME", output
+  end
+end


### PR DESCRIPTION
Add Energy CLI development environment tool
Energy CLI is a development environment for energy frameworks It can be installed, compiled, and packaged from the development environment

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
